### PR TITLE
Add support for mobileconfig signing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,3 +30,5 @@
 2022.0 (2022-03-31): Simplified database initialisation is now possible via HTTP POST and a JSON payload.
 
 2022.1 (2022-05-20): Request content type verification now works if additional parameters like "charset" are passed.
+
+2022.2 (2022-06-03): Add support for mobileconfig signing.

--- a/automx2/__init__.py
+++ b/automx2/__init__.py
@@ -82,6 +82,21 @@ class LdapNoMatch(NotFoundException):
     pass
 
 
+class NoCertsForSigningMobileconfig(AutomxException):
+    """Database did not contain the required certificates for mobileconfig signing."""
+    pass
+
+
+class NoKeyForSigningMobileconfig(AutomxException):
+    """Database did not contain the required key for mobileconfig signing."""
+    pass
+
+
+class MobileConfigSigningError(AutomxException):
+    """An error occurred while signing mobileconfig content."""
+    pass
+
+
 log = logging.getLogger(__name__)
 _handler = logging.StreamHandler()
 _handler.setFormatter(logging.Formatter())

--- a/automx2/generators/__init__.py
+++ b/automx2/generators/__init__.py
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with automx2. If not, see <https://www.gnu.org/licenses/>.
 """
-from typing import List
+from typing import List, Union
 from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import tostring
 
@@ -35,7 +35,7 @@ def branded_id(id_) -> str:
     return f'{IDENTIFIER}-{id_}'
 
 
-def xml_to_string(root_element: Element) -> str:
+def xml_to_string(root_element: Element) -> Union[str ,bytes]:
     return tostring(root_element, 'utf-8')
 
 

--- a/automx2/model.py
+++ b/automx2/model.py
@@ -39,6 +39,9 @@ class Provider(db.Model):
     id = db.Column(db.Integer, nullable=False, primary_key=True, autoincrement=True)
     name = db.Column(db.String(128), nullable=False)
     short_name = db.Column(db.String(32), nullable=False)
+    sign = db.Column(db.Boolean, nullable=False, default=False)
+    sign_cert = db.Column(db.String, nullable=True, default=None)
+    sign_key = db.Column(db.String, nullable=True, default=None)
     domains = db.relationship('Domain', lazy='select', backref=db.backref('provider', lazy='joined'))
 
     def __repr__(self) -> str:

--- a/automx2/views/mobileconfig.py
+++ b/automx2/views/mobileconfig.py
@@ -16,6 +16,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with automx2. If not, see <https://www.gnu.org/licenses/>.
 """
+from typing import Union
+
 from flask import abort
 from flask import request
 from flask.views import MethodView
@@ -34,7 +36,7 @@ class AppleView(MailConfig, MethodView):
     """Autoconfigure mail, Apple-style."""
 
     @staticmethod
-    def response_type() -> str:
+    def response_type() -> Union[str, bytes]:
         return CONTENT_TYPE_APPLE
 
     def get(self):
@@ -53,6 +55,6 @@ class AppleView(MailConfig, MethodView):
             log.exception(e)
             abort(400)
 
-    def config_response(self, local_part, domain_part: str, realname: str, password: str) -> str:
+    def config_response(self, local_part, domain_part: str, realname: str, password: str) -> Union[str, bytes]:
         data = AppleGenerator().client_config(local_part, domain_part, realname)
         return data

--- a/contrib/mysql-schema.sql
+++ b/contrib/mysql-schema.sql
@@ -108,6 +108,9 @@ CREATE TABLE `provider` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(128) NOT NULL,
   `short_name` varchar(32) NOT NULL,
+  `sign` tinyint(1) DEFAULT 0 NOT NULL,
+  `sign_cert` text NULL,
+  `sign_key` text NULL
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1003 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/contrib/postgres-schema.sql
+++ b/contrib/postgres-schema.sql
@@ -156,7 +156,10 @@ ALTER SEQUENCE public.ldapserver_id_seq OWNED BY public.ldapserver.id;
 CREATE TABLE public.provider (
     id integer NOT NULL,
     name character varying(128) NOT NULL,
-    short_name character varying(32) NOT NULL
+    short_name character varying(32) NOT NULL,
+	sign boolean DEFAULT 0 NOT NULL,
+	sign_cert text null,
+	sign_key text null
 );
 
 

--- a/contrib/sqlite-schema.sql
+++ b/contrib/sqlite-schema.sql
@@ -1,7 +1,10 @@
 CREATE TABLE provider (
 	id INTEGER NOT NULL, 
 	name VARCHAR(128) NOT NULL, 
-	short_name VARCHAR(32) NOT NULL, 
+	short_name VARCHAR(32) NOT NULL,
+	sign BOOLEAN DEFAULT 0 NOT NULL,
+	sign_cert TEXT null,
+	sign_key TEXT null,
 	PRIMARY KEY (id)
 );
 CREATE TABLE server (

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ SQLAlchemy>=1.3.11
 alembic>=1.3.1
 Flask-Migrate>=2.5.2
 ldap3>=2.6
+M2Crypto>=0.37.1


### PR DESCRIPTION
This is a first attempt at supporting mobileconfig signing as a per "provider" basis.

This adds 3 columns to the provider table:
- sign - enable or disable signing for this provider (0/1)
- sign_key - The signing private key for the provider
- sign_cert - The signing corresponding certificate for the provider

It requires M2Crypto python package and some system packages (example for debian/ubuntu):

- build-essential
- python3-dev or python-dev
- libssl-dev
- swig

TODO ?:
- Maybe find a more secure way to store private key in the DB
- Document the usage
- Add tests